### PR TITLE
Added restrictions on which objects and where it can be replicated

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,18 +17,35 @@ $ kubectl apply -f https://raw.githubusercontent.com/mittwald/kubernetes-replica
 
 ## Usage
 
-Add the annotation `replicator.v1.mittwald.de/replicate-from` to any Kubernetes
-secret or config map object. The value of that annotation should contain the
-the name of another secret or config map (using `<namespace>/<name>` notation).
+### 1. Create the source secret
 
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  annotations:
-    replicator.v1.mittwald.de/replicate-from: default/some-secret
-data: {}
-```
+- If a secret or configMap needs to be replicated to other namespaces, annotations should be added in that object permitting replication. 
+  - Add `replicator.v1.mittwald.de/replication-allowed` annotation with value `True` indicating that the object can be replicated.
+  - Add `replicator.v1.mittwald.de/replication-allowed-namespaces` annotation. Value of this annotation should contain a comma separated list or permitted namespaces or regular expressions. for e.g. `namespace-1,my-ns-2,app-ns-[0-9]*`, in this case replication will be performed only names `namespace-1`, `my-ns-2` and any namespace that matches the regular expression `app-ns-[0-9]*`.
 
-The replicator will then copy the `data` attribute of the referenced object into
-the annotated object and keep them in sync.   
+    ```yaml
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      annotations:
+        replicator.v1.mittwald.de/replicate-allowed: True
+        replicator.v1.mittwald.de/replicate-allowed-namespaces: "my-ns-1,namespace-[0-9]*"
+    data:
+      key1: <value>
+    ```
+
+### 2. Create empty secret
+
+
+- Add the annotation `replicator.v1.mittwald.de/replicate-from` to any Kubernetes secret or config map object. The value of that annotation should contain the the name of another secret or config map (using `<namespace>/<name>` notation).
+
+  ```yaml
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    annotations:
+      replicator.v1.mittwald.de/replicate-from: default/some-secret
+  data: {}
+  ```
+
+  The replicator will then copy the `data` attribute of the referenced object into the annotated object and keep them in sync.   

--- a/replicate/common.go
+++ b/replicate/common.go
@@ -1,20 +1,68 @@
 package replicate
 
 import (
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
+    "k8s.io/client-go/kubernetes"
+    "k8s.io/client-go/tools/cache"
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+    "fmt"
+    "strconv"
+    "strings"
+    "regexp"
 )
 
 type replicatorProps struct {
-	client     kubernetes.Interface
-	store      cache.Store
-	controller cache.Controller
+    client     kubernetes.Interface
+    store      cache.Store
+    controller cache.Controller
 
-	dependencyMap map[string][]string
+    dependencyMap map[string][]string
 }
 
 // Replicator describes the common interface that the secret and configmap
-// replicators shoud adhere to
+// replicators should adhere to
 type Replicator interface {
-	Run()
+    Run()
+}
+
+// Checks if replication is allowed in annotations of the source object
+// Returns true if replication is allowed. If replication is not allowed returns false with
+// error message
+func isReplicationPermitted(object *metav1.ObjectMeta, sourceObject *metav1.ObjectMeta) (bool, error) {
+    // make sure source object allows replication
+    annotationAllowed, ok := sourceObject.Annotations[ReplicationAllowed]
+    if !ok {
+        return false, fmt.Errorf("source %s/%s does not allow replication. %s will not be replicated",
+            sourceObject.Namespace, sourceObject.Name, object.Name)
+    }
+    annotationAllowedBool, err := strconv.ParseBool(annotationAllowed)
+
+    // check if source object allows replication
+    if err != nil || !annotationAllowedBool {
+        return false, fmt.Errorf("source %s/%s does not allow replication. %s will not be replicated",
+            sourceObject.Namespace, sourceObject.Name, object.Name)
+    }
+
+    // check if the target namespace is permitted
+    annotationAllowedNamespaces, ok := sourceObject.Annotations[ReplicationAllowedNamespaces]
+    if !ok {
+        return false, fmt.Errorf(
+            "source %s/%s does not allow replication in namespace %s. %s will not be replicated",
+            sourceObject.Namespace, sourceObject.Name, object.Namespace, object.Name)
+    }
+    allowedNamespaces := strings.Split(annotationAllowedNamespaces, ",")
+    allowed := false
+    for _, ns := range allowedNamespaces {
+        if matched, _ := regexp.MatchString(ns, object.Namespace); matched {
+            allowed = true
+            break
+        }
+    }
+
+    err = nil
+    if !allowed {
+        err = fmt.Errorf(
+            "source %s/%s does not allow replication in namespace %s. %s will not be replicated",
+            sourceObject.Namespace, sourceObject.Name, object.Namespace, object.Name)
+    }
+    return allowed, err
 }

--- a/replicate/common.go
+++ b/replicate/common.go
@@ -1,68 +1,68 @@
 package replicate
 
 import (
-    "k8s.io/client-go/kubernetes"
-    "k8s.io/client-go/tools/cache"
-    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-    "fmt"
-    "strconv"
-    "strings"
-    "regexp"
+	"fmt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"regexp"
+	"strconv"
+	"strings"
 )
 
 type replicatorProps struct {
-    client     kubernetes.Interface
-    store      cache.Store
-    controller cache.Controller
+	client     kubernetes.Interface
+	store      cache.Store
+	controller cache.Controller
 
-    dependencyMap map[string][]string
+	dependencyMap map[string][]string
 }
 
 // Replicator describes the common interface that the secret and configmap
 // replicators should adhere to
 type Replicator interface {
-    Run()
+	Run()
 }
 
 // Checks if replication is allowed in annotations of the source object
 // Returns true if replication is allowed. If replication is not allowed returns false with
 // error message
 func isReplicationPermitted(object *metav1.ObjectMeta, sourceObject *metav1.ObjectMeta) (bool, error) {
-    // make sure source object allows replication
-    annotationAllowed, ok := sourceObject.Annotations[ReplicationAllowed]
-    if !ok {
-        return false, fmt.Errorf("source %s/%s does not allow replication. %s will not be replicated",
-            sourceObject.Namespace, sourceObject.Name, object.Name)
-    }
-    annotationAllowedBool, err := strconv.ParseBool(annotationAllowed)
+	// make sure source object allows replication
+	annotationAllowed, ok := sourceObject.Annotations[ReplicationAllowed]
+	if !ok {
+		return false, fmt.Errorf("source %s/%s does not allow replication. %s will not be replicated",
+			sourceObject.Namespace, sourceObject.Name, object.Name)
+	}
+	annotationAllowedBool, err := strconv.ParseBool(annotationAllowed)
 
-    // check if source object allows replication
-    if err != nil || !annotationAllowedBool {
-        return false, fmt.Errorf("source %s/%s does not allow replication. %s will not be replicated",
-            sourceObject.Namespace, sourceObject.Name, object.Name)
-    }
+	// check if source object allows replication
+	if err != nil || !annotationAllowedBool {
+		return false, fmt.Errorf("source %s/%s does not allow replication. %s will not be replicated",
+			sourceObject.Namespace, sourceObject.Name, object.Name)
+	}
 
-    // check if the target namespace is permitted
-    annotationAllowedNamespaces, ok := sourceObject.Annotations[ReplicationAllowedNamespaces]
-    if !ok {
-        return false, fmt.Errorf(
-            "source %s/%s does not allow replication in namespace %s. %s will not be replicated",
-            sourceObject.Namespace, sourceObject.Name, object.Namespace, object.Name)
-    }
-    allowedNamespaces := strings.Split(annotationAllowedNamespaces, ",")
-    allowed := false
-    for _, ns := range allowedNamespaces {
-        if matched, _ := regexp.MatchString(ns, object.Namespace); matched {
-            allowed = true
-            break
-        }
-    }
+	// check if the target namespace is permitted
+	annotationAllowedNamespaces, ok := sourceObject.Annotations[ReplicationAllowedNamespaces]
+	if !ok {
+		return false, fmt.Errorf(
+			"source %s/%s does not allow replication in namespace %s. %s will not be replicated",
+			sourceObject.Namespace, sourceObject.Name, object.Namespace, object.Name)
+	}
+	allowedNamespaces := strings.Split(annotationAllowedNamespaces, ",")
+	allowed := false
+	for _, ns := range allowedNamespaces {
+		if matched, _ := regexp.MatchString(ns, object.Namespace); matched {
+			allowed = true
+			break
+		}
+	}
 
-    err = nil
-    if !allowed {
-        err = fmt.Errorf(
-            "source %s/%s does not allow replication in namespace %s. %s will not be replicated",
-            sourceObject.Namespace, sourceObject.Name, object.Namespace, object.Name)
-    }
-    return allowed, err
+	err = nil
+	if !allowed {
+		err = fmt.Errorf(
+			"source %s/%s does not allow replication in namespace %s. %s will not be replicated",
+			sourceObject.Namespace, sourceObject.Name, object.Namespace, object.Name)
+	}
+	return allowed, err
 }

--- a/replicate/configmaps.go
+++ b/replicate/configmaps.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -102,6 +104,13 @@ func (r *configMapReplicator) ConfigMapAdded(obj interface{}) {
 }
 
 func (r *configMapReplicator) replicateConfigMap(configMap *v1.ConfigMap, sourceConfigMap *v1.ConfigMap) error {
+	// make sure replication is allowed
+	if ok, err := r.isReplicationPermitted(configMap, sourceConfigMap); !ok {
+		// skip replication
+		log.Printf("Error %s", err)
+		return err
+	}
+
 	targetVersion, ok := configMap.Annotations[ReplicatedFromVersionAnnotation]
 	sourceVersion := sourceConfigMap.ResourceVersion
 
@@ -132,6 +141,38 @@ func (r *configMapReplicator) replicateConfigMap(configMap *v1.ConfigMap, source
 
 	r.store.Update(s)
 	return nil
+}
+
+func (r *configMapReplicator) isReplicationPermitted(configMap *v1.ConfigMap, sourceConfigMap *v1.ConfigMap) (bool, error) {
+	// make sure source object allows replication
+	annotationAllowed, ok := sourceConfigMap.Annotations[ReplicationAllowed]
+	if !ok {
+		return false, fmt.Errorf("source configmap %s/%s does not allow replication. %s will not be replicated", sourceConfigMap.Namespace, sourceConfigMap.Name, configMap.Name)
+	}
+	annotationAllowedBool, err := strconv.ParseBool(annotationAllowed)
+
+	// check if source allows replication
+	if err != nil || !annotationAllowedBool {
+		return false, fmt.Errorf("source configmap %s/%s does not allow replication. %s will not be replicated", sourceConfigMap.Namespace, sourceConfigMap.Name, configMap.Name)
+	}
+
+	// check if the target namespace is permitted
+	annotationAllowedNamespaces, ok := sourceConfigMap.Annotations[ReplicationAllowedNamespaces]
+	if !ok {
+		return false, fmt.Errorf("source configmap %s/%s does not allow replication in namespace %s. %s will not be replicated", sourceConfigMap.Namespace, sourceConfigMap.Name, configMap.Namespace, configMap.Name)
+	}
+	allowedNamespaces := strings.Split(annotationAllowedNamespaces, ",")
+	atleastOneAllowed := false
+	for _, ns := range allowedNamespaces {
+		if matched, _ := regexp.MatchString(ns, configMap.Namespace); matched {
+			atleastOneAllowed = true
+			break
+		}
+	}
+	if !atleastOneAllowed {
+		return false, fmt.Errorf("source configmap %s/%s does not allow replication in namespace %s. %s will not be replicated", sourceConfigMap.Namespace, sourceConfigMap.Name, configMap.Namespace, configMap.Name)
+	}
+	return true, nil
 }
 
 func (r *configMapReplicator) configMapFromStore(key string) (*v1.ConfigMap, error) {

--- a/replicate/consts.go
+++ b/replicate/consts.go
@@ -5,4 +5,6 @@ const (
 	ReplicateFromAnnotation         = "replicator.v1.mittwald.de/replicate-from"
 	ReplicatedAtAnnotation          = "replicator.v1.mittwald.de/replicated-at"
 	ReplicatedFromVersionAnnotation = "replicator.v1.mittwald.de/replicated-from-version"
+	ReplicationAllowed              = "replicator.v1.mittwald.de/replication-allowed"
+	ReplicationAllowedNamespaces    = "replicator.v1.mittwald.de/replication-allowed-namespaces"
 )

--- a/replicate/secrets.go
+++ b/replicate/secrets.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -104,6 +106,13 @@ func (r *secretReplicator) SecretAdded(obj interface{}) {
 }
 
 func (r *secretReplicator) replicateSecret(secret *v1.Secret, sourceSecret *v1.Secret) error {
+	// make sure replication is allowed
+	if ok, err := r.isReplicationPermitted(secret, sourceSecret); !ok {
+		// skip replication
+		log.Printf("Error %s", err)
+		return err
+	}
+
 	targetVersion, ok := secret.Annotations[ReplicatedFromVersionAnnotation]
 	sourceVersion := sourceSecret.ResourceVersion
 
@@ -136,6 +145,38 @@ func (r *secretReplicator) replicateSecret(secret *v1.Secret, sourceSecret *v1.S
 
 	r.store.Update(s)
 	return nil
+}
+
+func (r *secretReplicator) isReplicationPermitted(secret *v1.Secret, sourceSecret *v1.Secret) (bool, error) {
+	// make sure source object allows replication
+	annotationAllowed, ok := sourceSecret.Annotations[ReplicationAllowed]
+	if !ok {
+		return false, fmt.Errorf("source secret %s/%s does not allow replication. %s will not be replicated", sourceSecret.Namespace, sourceSecret.Name, secret.Name)
+	}
+	annotationAllowedBool, err := strconv.ParseBool(annotationAllowed)
+
+	// check if source secret allows replication
+	if err != nil || !annotationAllowedBool {
+		return false, fmt.Errorf("source secret %s/%s does not allow replication. %s will not be replicated", sourceSecret.Namespace, sourceSecret.Name, secret.Name)
+	}
+
+	// check if the target namespace is permitted
+	annotationAllowedNamespaces, ok := sourceSecret.Annotations[ReplicationAllowedNamespaces]
+	if !ok {
+		return false, fmt.Errorf("source secret %s/%s does not allow replication in namespace %s. %s will not be replicated", sourceSecret.Namespace, sourceSecret.Name, secret.Namespace, secret.Name)
+	}
+	allowedNamespaces := strings.Split(annotationAllowedNamespaces, ",")
+	atleastOneAllowed := false
+	for _, ns := range allowedNamespaces {
+		if matched, _ := regexp.MatchString(ns, secret.Namespace); matched {
+			atleastOneAllowed = true
+			break
+		}
+	}
+	if !atleastOneAllowed {
+		return false, fmt.Errorf("source secret %s/%s does not allow replication in namespace %s. %s will not be replicated", sourceSecret.Namespace, sourceSecret.Name, secret.Namespace, secret.Name)
+	}
+	return true, nil
 }
 
 func (r *secretReplicator) secretFromStore(key string) (*v1.Secret, error) {


### PR DESCRIPTION
By default, the replicator replicated any `ConfigMap` or `Secret` object to any namespace as the replicator is permitted to do so. This opens up potential security vulnerabilities.

This PR adds restrictions on which objects can be replicated and where that can be replicated. Restrictions are added as annotations in source objects, hence its controlled at the source.