### PR TITLE
Make serviceAccount name in deployment match what is created in rbac

### DIFF
--- a/deploy/helm-chart/kubernetes-replicator/templates/deployment.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
               port: health
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      serviceAccountName: {{ include "kubernetes-replicator.name" . }}
+      serviceAccountName: {{ include "kubernetes-replicator.fullname" . }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Fixes a naming mismatch when you install replicator in a different namespace