### PR TITLE
Add support for binaryData

### DIFF
--- a/replicate/configmaps.go
+++ b/replicate/configmaps.go
@@ -130,6 +130,14 @@ func (r *configMapReplicator) replicateConfigMap(configMap *v1.ConfigMap, source
 	for key, value := range sourceConfigMap.Data {
 		configMapCopy.Data[key] = value
 	}
+	
+	if sourceConfigMap.BinaryData != nil {
+		configMapCopy.BinaryData = make(map[string]string)
+		for key, value := range sourceConfigMap.BinaryData {
+			configMapCopy.BinaryData[key] = value
+		}
+	}
+
 
 	log.Printf("updating config map %s/%s", configMap.Namespace, configMap.Name)
 


### PR DESCRIPTION
As of k8s v1.10, a binaryData field is allowed on configmaps to store base64-encoded binary string. This adds support for replicating this field iff it exists in the source configmap.