### PR TITLE
Add support for StringData in secrets

### DIFF
--- a/replicate/secrets.go
+++ b/replicate/secrets.go
@@ -132,6 +132,13 @@ func (r *secretReplicator) replicateSecret(secret *v1.Secret, sourceSecret *v1.S
 		copy(newValue, value)
 		secretCopy.Data[key] = newValue
 	}
+	
+	if sourceSecret.StringData != nil {
+		secretCopy.StringData = make(map[string]string)
+		for key, value := range sourceSecret.StringData {
+			secretCopy.StringData[key] = value
+		}
+	}
 
 	log.Printf("updating secret %s/%s", secret.Namespace, secret.Name)
 


### PR DESCRIPTION
This is identical to the PR made yesterday, except for the reverse situation in secrets. Secrets automatically assume all fields in data are base64-encoded, and now contain a new field, StringData, which allows a secret to contain non-base64-encoded data. This PR adds support for replicating StringData fields in secrets.

I double checked that the map is [string]string this time :)