### PR TITLE
Support creating target object before source object

### DIFF
--- a/replicate/configmaps.go
+++ b/replicate/configmaps.go
@@ -91,7 +91,7 @@ func (r *configMapReplicator) ConfigMapAdded(obj interface{}) {
 	}
 
 	r.dependencyMap[val][configMapKey] = nil
-	
+
 	sourceObject, exists, err := r.store.GetByKey(val)
 	if err != nil {
 		log.Printf("could not get config map %s: %s", val, err)

--- a/replicate/configmaps.go
+++ b/replicate/configmaps.go
@@ -86,6 +86,12 @@ func (r *configMapReplicator) ConfigMapAdded(obj interface{}) {
 		return
 	}
 
+	if _, ok := r.dependencyMap[val]; !ok {
+		r.dependencyMap[val] = make(map[string]interface{})
+	}
+
+	r.dependencyMap[val][configMapKey] = nil
+	
 	sourceObject, exists, err := r.store.GetByKey(val)
 	if err != nil {
 		log.Printf("could not get config map %s: %s", val, err)
@@ -94,12 +100,6 @@ func (r *configMapReplicator) ConfigMapAdded(obj interface{}) {
 		log.Printf("could not get config map %s: does not exist", val)
 		return
 	}
-
-	if _, ok := r.dependencyMap[val]; !ok {
-		r.dependencyMap[val] = make(map[string]interface{})
-	}
-
-	r.dependencyMap[val][configMapKey] = nil
 
 	sourceConfigMap := sourceObject.(*v1.ConfigMap)
 

--- a/replicate/secrets.go
+++ b/replicate/secrets.go
@@ -85,6 +85,12 @@ func (r *secretReplicator) SecretAdded(obj interface{}) {
 	if len(v) < 2 {
 		return
 	}
+	
+	if _, ok := r.dependencyMap[val]; !ok {
+		r.dependencyMap[val] = make(map[string]interface{})
+	}
+
+	r.dependencyMap[val][secretKey] = nil
 
 	sourceObject, exists, err := r.store.GetByKey(val)
 	if err != nil {
@@ -94,12 +100,6 @@ func (r *secretReplicator) SecretAdded(obj interface{}) {
 		log.Printf("could not get secret %s: does not exist", val)
 		return
 	}
-
-	if _, ok := r.dependencyMap[val]; !ok {
-		r.dependencyMap[val] = make(map[string]interface{})
-	}
-
-	r.dependencyMap[val][secretKey] = nil
 
 	sourceSecret := sourceObject.(*v1.Secret)
 

--- a/replicate/secrets.go
+++ b/replicate/secrets.go
@@ -85,7 +85,7 @@ func (r *secretReplicator) SecretAdded(obj interface{}) {
 	if len(v) < 2 {
 		return
 	}
-	
+
 	if _, ok := r.dependencyMap[val]; !ok {
 		r.dependencyMap[val] = make(map[string]interface{})
 	}


### PR DESCRIPTION
This implements a fix for #33. I've tested this on a cluster & this appears to work as intended (see logs).

It does seem to create some spurious logs on startup, depending on the order of the initial secret read.

```
2020/02/15 02:38:53 using in-cluster configuration
2020/02/15 02:38:53 starting liveness monitor at :9102
2020/02/15 02:38:53 running secret controller
2020/02/15 02:38:53 running config map controller
2020/02/15 02:38:53 secret jenkins/better-tls-3.dev.source.ai-tls is replicated from kube-system/better-tls-3.dev.source.ai-tls
2020/02/15 02:38:53 could not get secret kube-system/better-tls-3.dev.source.ai-tls: does not exist
2020/02/15 02:38:53 secret default/better-tls-3.dev.source.ai-tls is replicated from kube-system/better-tls-3.dev.source.ai-tls
2020/02/15 02:38:53 could not get secret kube-system/better-tls-3.dev.source.ai-tls: does not exist
2020/02/15 02:38:53 secret kube-system/better-tls-3.dev.source.ai-tls has 2 dependents
2020/02/15 02:38:53 updating dependent secret kube-system/better-tls-3.dev.source.ai-tls -> jenkins/better-tls-3.dev.source.ai-tls
2020/02/15 02:38:53 secret jenkins/better-tls-3.dev.source.ai-tls is already up-to-date
2020/02/15 02:38:53 updating dependent secret kube-system/better-tls-3.dev.source.ai-tls -> default/better-tls-3.dev.source.ai-tls
2020/02/15 02:38:53 secret default/better-tls-3.dev.source.ai-tls is already up-to-date
2020/02/15 02:39:55 secret default/test-destination is replicated from default/test-source
2020/02/15 02:39:55 could not get secret default/test-source: does not exist
2020/02/15 02:40:03 secret default/test-source has 1 dependents
2020/02/15 02:40:03 updating dependent secret default/test-source -> default/test-destination
2020/02/15 02:40:03 replication of secret default/test-source is not permitted: source default/test-source does not allow replication. test-destination will not be replicated
2020/02/15 02:40:03 secret default/test-source has 1 dependents
2020/02/15 02:40:03 updating dependent secret default/test-source -> default/test-destination
2020/02/15 02:40:03 replication of secret default/test-source is not permitted: source default/test-source does not allow replication (replicator.v1.mittwald.de/replication-allowed-namespaces annotation missing). test-destination will not be replicated
2020/02/15 02:40:03 secret default/test-source has 1 dependents
2020/02/15 02:40:03 updating dependent secret default/test-source -> default/test-destination
2020/02/15 02:40:03 updating secret default/test-destination
2020/02/15 02:40:03 secret default/test-destination is replicated from default/test-source
2020/02/15 02:40:03 secret default/test-destination is already up-to-date
```