### PR TITLE
Manifest updates and add missing permissions for the helm template's RBAC manifest

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -1,16 +1,41 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: replicator-deployment
+  name: replicator-kubernetes-replicator
   namespace: kube-system
+  labels:
+    app.kubernetes.io/name: kubernetes-replicator
+    app.kubernetes.io/instance: replicator
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubernetes-replicator
+      app.kubernetes.io/instance: replicator
   template:
     metadata:
       labels:
-        app: replicator
+        app.kubernetes.io/name: kubernetes-replicator
+        app.kubernetes.io/instance: replicator
     spec:
-      serviceAccountName: replicator
+      serviceAccountName: replicator-kubernetes-replicator
+      securityContext: {}
       containers:
-        - name: replicator
-          image: quay.io/mittwald/kubernetes-replicator:latest
+      - name: kubernetes-replicator
+        securityContext: {}
+        image: quay.io/mittwald/kubernetes-replicator:latest
+        imagePullPolicy: Always
+        args: []
+        ports:
+        - name: health
+          containerPort: 9102
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: health
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: health
+        resources: {}

--- a/deploy/helm-chart/kubernetes-replicator/templates/rbac.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/templates/rbac.yaml
@@ -17,6 +17,9 @@ metadata:
   labels:
     {{- include "kubernetes-replicator.labels" . | nindent 4 }}
 rules:
+  - apiGroups: [ "" ]
+    resources: [ "namespaces" ]
+    verbs: [ "get", "watch", "list" ]
   - apiGroups: [""] # "" indicates the core API group
     resources: ["secrets", "configmaps"]
     verbs: ["get", "watch", "list", "update", "patch"]

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -1,33 +1,33 @@
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: v1
+kind: ServiceAccount
 metadata:
-  name: mittwald:replicator
-rules:
-  - apiGroups: [""]
-    resources: ["namespaces"]
-    verbs: ["get", "watch", "list"]
-  - apiGroups: [""] # "" indicates the core API group
-    resources: ["secrets", "configmaps"]
-    verbs: ["get", "watch", "list", "update", "patch"]
-  - apiGroups: ["rbac.authorization.k8s.io"]
-    resources: ["roles", "rolebindings"]
-    verbs: ["get", "watch", "list", "update", "patch"]
+  name: replicator-kubernetes-replicator
+  namespace: kube-system
 ---
-kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
-  name: mittwald:replicator
+  name: replicator-kubernetes-replicator
+rules:
+- apiGroups: [ "" ]
+  resources: [ "namespaces" ]
+  verbs: [ "get", "watch", "list" ]
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["secrets", "configmaps"]
+  verbs: ["get", "watch", "list", "update", "patch"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles", "rolebindings"]
+  verbs: ["get", "watch", "list", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: replicator-kubernetes-replicator
 roleRef:
   kind: ClusterRole
-  name: mittwald:replicator
+  name: replicator-kubernetes-replicator
   apiGroup: rbac.authorization.k8s.io
 subjects:
-  - kind: ServiceAccount
-    name: replicator
-    namespace: kube-system
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: replicator
+- kind: ServiceAccount
+  name: replicator-kubernetes-replicator
   namespace: kube-system


### PR DESCRIPTION
Seems like the helm-generated rbac manifest is missing the permissions to read namespaces:
```
E0910 19:53:10.924301       1 reflector.go:153] pkg/mod/k8s.io/client-go@v0.17.3/tools/cache/reflector.go:105: Failed to list *v1.Namespace: namespaces is forbidden: User "system:serviceaccount:kube-system:replicator-kubernetes-replicator" cannot list resource "namespaces" in API group "" at the cluster scope
```
This change adds the required permissions to the cluster role on the helm rbac template.
While at it, I noticed that the manual deployment manifest is very old to a point of still using the `extensions` apiGroup which is deprecated, so I aligned the manifest with a few needed updates.