### PR TITLE
Adding missing RBAC verbs for push-based replication to work properly

### DIFF
--- a/deploy/helm-chart/kubernetes-replicator/templates/rbac.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/templates/rbac.yaml
@@ -22,10 +22,10 @@ rules:
     verbs: [ "get", "watch", "list" ]
   - apiGroups: [""] # "" indicates the core API group
     resources: ["secrets", "configmaps"]
-    verbs: ["get", "watch", "list", "update", "patch"]
+    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["roles", "rolebindings"]
-    verbs: ["get", "watch", "list", "update", "patch"]
+    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -14,10 +14,10 @@ rules:
   verbs: [ "get", "watch", "list" ]
 - apiGroups: [""] # "" indicates the core API group
   resources: ["secrets", "configmaps"]
-  verbs: ["get", "watch", "list", "update", "patch"]
+  verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["roles", "rolebindings"]
-  verbs: ["get", "watch", "list", "update", "patch"]
+  verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
I've noticed that when testing the push-based replication, new secrets weren't getting created and deleted accordingly when using the newly introduced push-based replication. After updating the clusterRole with the two added verbs- it started working as expected.