### PR TITLE
copy labels when replicating resources to other namespaces

### DIFF
--- a/replicate/configmap/configmaps.go
+++ b/replicate/configmap/configmaps.go
@@ -189,8 +189,16 @@ func (r *Replicator) ReplicateObjectTo(sourceObj interface{}, target *v1.Namespa
 		}
 	}
 
+	labelsCopy := make(map[string]string)
+	if source.Labels != nil {
+		for key, value := range source.Labels {
+			labelsCopy[key] = value
+		}
+	}
+
 	sort.Strings(replicatedKeys)
 	resourceCopy.Name = source.Name
+	resourceCopy.Labels = labelsCopy
 	resourceCopy.Annotations[common.ReplicatedAtAnnotation] = time.Now().Format(time.RFC3339)
 	resourceCopy.Annotations[common.ReplicatedFromVersionAnnotation] = source.ResourceVersion
 	resourceCopy.Annotations[common.ReplicatedKeysAnnotation] = strings.Join(replicatedKeys, ",")

--- a/replicate/role/roles.go
+++ b/replicate/role/roles.go
@@ -130,7 +130,15 @@ func (r *Replicator) ReplicateObjectTo(sourceObj interface{}, target *v1.Namespa
 		targetCopy.Annotations = make(map[string]string)
 	}
 
+	labelsCopy := make(map[string]string)
+	if source.Labels != nil {
+		for key, value := range source.Labels {
+			labelsCopy[key] = value
+		}
+	}
+
 	targetCopy.Name = source.Name
+	targetCopy.Labels = labelsCopy
 	targetCopy.Rules = source.Rules
 	targetCopy.Annotations[common.ReplicatedAtAnnotation] = time.Now().Format(time.RFC3339)
 	targetCopy.Annotations[common.ReplicatedFromVersionAnnotation] = source.ResourceVersion

--- a/replicate/rolebinding/rolebindings.go
+++ b/replicate/rolebinding/rolebindings.go
@@ -126,7 +126,15 @@ func (r *Replicator) ReplicateObjectTo(sourceObj interface{}, target *v1.Namespa
 		targetCopy.Annotations = make(map[string]string)
 	}
 
+	labelsCopy := make(map[string]string)
+	if source.Labels != nil {
+		for key, value := range source.Labels {
+			labelsCopy[key] = value
+		}
+	}
+
 	targetCopy.Name = source.Name
+	targetCopy.Labels = labelsCopy
 	targetCopy.Subjects = source.Subjects
 	targetCopy.RoleRef = source.RoleRef
 	targetCopy.Annotations[common.ReplicatedAtAnnotation] = time.Now().Format(time.RFC3339)

--- a/replicate/secret/secrets.go
+++ b/replicate/secret/secrets.go
@@ -160,7 +160,16 @@ func (r *Replicator) ReplicateObjectTo(sourceObj interface{}, target *v1.Namespa
 	replicatedKeys := r.extractReplicatedKeys(source, targetLocation, resourceCopy)
 
 	sort.Strings(replicatedKeys)
+
+	labelsCopy := make(map[string]string)
+	if source.Labels != nil {
+		for key, value := range source.Labels {
+			labelsCopy[key] = value
+		}
+	}
+
 	resourceCopy.Name = source.Name
+	resourceCopy.Labels = labelsCopy
 	resourceCopy.Type = targetResourceType
 	resourceCopy.Annotations[common.ReplicatedAtAnnotation] = time.Now().Format(time.RFC3339)
 	resourceCopy.Annotations[common.ReplicatedFromVersionAnnotation] = source.ResourceVersion


### PR DESCRIPTION
fixes: https://github.com/mittwald/kubernetes-replicator/issues/57

Copy labels on resources when using replicate-to, this is needed so we can do operations like `kubectl get configmap -l xyz`