### PR TITLE
Added Helm variable to add extra pod labels

### DIFF
--- a/deploy/helm-chart/kubernetes-replicator/templates/deployment.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/templates/deployment.yaml
@@ -13,6 +13,9 @@ spec:
     metadata:
       labels:
         {{- include "kubernetes-replicator.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/deploy/helm-chart/kubernetes-replicator/templates/deployment.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/templates/deployment.yaml
@@ -11,6 +11,10 @@ spec:
       {{- include "kubernetes-replicator.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "kubernetes-replicator.selectorLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}

--- a/deploy/helm-chart/kubernetes-replicator/values.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/values.yaml
@@ -40,3 +40,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+podLabels: {}

--- a/deploy/helm-chart/kubernetes-replicator/values.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/values.yaml
@@ -42,3 +42,5 @@ tolerations: []
 affinity: {}
 
 podLabels: {}
+
+podAnnotations: {}


### PR DESCRIPTION
We need to add custom labels to pods we deploy into our clusters. Currently we do this by using Helm template and Kustomize on the resulting yaml files before we deploy the Kubernetes replicator.

We would like to add labels without this extra step as we are about to change our deployment process and this additional feature will simplify our new deployment process. This PR enables labeling of pods without the need to do apply the extra Kustomize step.