### PR TITLE
Added readiness and liveness values in helm

### DIFF
--- a/deploy/helm-chart/kubernetes-replicator/templates/deployment.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/templates/deployment.yaml
@@ -44,10 +44,20 @@ spec:
             httpGet:
               path: /healthz
               port: health
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           readinessProbe:
             httpGet:
               path: /healthz
               port: health
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/deploy/helm-chart/kubernetes-replicator/values.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/values.yaml
@@ -15,7 +15,7 @@ serviceAccount:
   annotations: {}
   name:
   privileges:
-    - apiGroups: [ "", "apps", "extensions" ] 
+    - apiGroups: [ "", "apps", "extensions" ]
       resources: ["secrets", "configmaps", "roles", "rolebindings",
       "cronjobs", "deployments", "events", "ingresses", "jobs", "pods", "pods/attach", "pods/exec", "pods/log", "pods/portforward", "services"]
     - apiGroups: [ "batch" ]
@@ -48,3 +48,17 @@ affinity: {}
 podLabels: {}
 
 podAnnotations: {}
+
+livenessProbe:
+  initialDelaySeconds: 60
+  periodSeconds: 10
+  timeoutSeconds: 1
+  failureThreshold: 3
+  successThreshold: 1
+
+readinessProbe:
+  initialDelaySeconds: 60
+  periodSeconds: 10
+  timeoutSeconds: 1
+  failureThreshold: 3
+  successThreshold: 1


### PR DESCRIPTION
We have the problem, that the start of the container takes around 60 sec and the healthcheck is failing. So we end in a restart loop. 

This PR exposes the values for livenessProbe and readynessProbe, so they can be configurated over helm values.