### PR TITLE
fixes #144 Helm Chart RBAC privileges

### DIFF
--- a/deploy/helm-chart/kubernetes-replicator/templates/rbac.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/templates/rbac.yaml
@@ -26,7 +26,7 @@ rules:
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["roles", "rolebindings"]
     verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
-{{- range .Values.serviceAccount.extraPrivileges }}
+{{- range .Values.serviceAccount.privileges }}
   - apiGroups: {{ .apiGroups | toYaml | nindent 6 }}
     resources: {{ .resources | toYaml | nindent 6 }}
     verbs: ["get", "watch", "list", "create", "update", "patch", "delete", "describe"]

--- a/deploy/helm-chart/kubernetes-replicator/templates/rbac.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/templates/rbac.yaml
@@ -20,14 +20,17 @@ rules:
   - apiGroups: [ "" ]
     resources: [ "namespaces" ]
     verbs: [ "get", "watch", "list" ]
-{{- range .Values.serviceAccount.privileges }}
+  - apiGroups: [""]
+    resources: ["secrets", "configmaps"]
+    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles", "rolebindings"]
+    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
+{{- range .Values.serviceAccount.extraPrivileges }}
   - apiGroups: {{ .apiGroups | toYaml | nindent 6 }}
     resources: {{ .resources | toYaml | nindent 6 }}
     verbs: ["get", "watch", "list", "create", "update", "patch", "delete", "describe"]
 {{- end }}
-  - apiGroups: ["rbac.authorization.k8s.io"]
-    resources: ["roles", "rolebindings"]
-    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/helm-chart/kubernetes-replicator/values.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/values.yaml
@@ -14,7 +14,9 @@ serviceAccount:
   create: true
   annotations: {}
   name:
-  extraPrivileges: []
+  privileges: []
+  # - apiGroups: [""]
+  #   resources: ["configmaps"]
 podSecurityContext: {}
   # fsGroup: 2000
 

--- a/deploy/helm-chart/kubernetes-replicator/values.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/values.yaml
@@ -14,12 +14,7 @@ serviceAccount:
   create: true
   annotations: {}
   name:
-  privileges:
-    - apiGroups: [ "", "apps", "extensions" ]
-      resources: ["secrets", "configmaps", "roles", "rolebindings",
-      "cronjobs", "deployments", "events", "ingresses", "jobs", "pods", "pods/attach", "pods/exec", "pods/log", "pods/portforward", "services"]
-    - apiGroups: [ "batch" ]
-      resources:  ["configmaps", "cronjobs", "deployments", "events", "ingresses", "jobs", "pods", "pods/attach", "pods/exec", "pods/log", "pods/portforward", "services"]
+  extraPrivileges: []
 podSecurityContext: {}
   # fsGroup: 2000
 


### PR DESCRIPTION
RBAC Helm template to inject mandatory privileges as per https://github.com/mittwald/kubernetes-replicator/blob/master/deploy/rbac.yaml and adds extraPrivileges to allow anybody out there to inject extra privileges but honestly I do not think is any use case for that at all.

This PR makes the Chart compatible with NSA hardening guide and kubescape checks.