### PR TITLE
Add a flag to disable push-based replication

### DIFF
--- a/config.go
+++ b/config.go
@@ -8,6 +8,7 @@ type flags struct {
 	ResyncPeriod  time.Duration
 	StatusAddr    string
 	AllowAll      bool
+	DisablePush   bool
 	LogLevel      string
 	LogFormat     string
 }

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ func init() {
 	flag.StringVar(&f.LogLevel, "log-level", "info", "Log level (trace, debug, info, warn, error)")
 	flag.StringVar(&f.LogFormat, "log-format", "plain", "Log format (plain, json)")
 	flag.BoolVar(&f.AllowAll, "allow-all", false, "allow replication of all secrets (CAUTION: only use when you know what you're doing)")
+	flag.BoolVar(&f.DisablePush, "disable-push", false, "disable Push-based replication")
 	flag.Parse()
 
 	switch strings.ToUpper(strings.TrimSpace(f.LogLevel)) {
@@ -80,10 +81,10 @@ func main() {
 
 	client = kubernetes.NewForConfigOrDie(config)
 
-	secretRepl := secret.NewReplicator(client, f.ResyncPeriod, f.AllowAll)
-	configMapRepl := configmap.NewReplicator(client, f.ResyncPeriod, f.AllowAll)
-	roleRepl := role.NewReplicator(client, f.ResyncPeriod, f.AllowAll)
-	roleBindingRepl := rolebinding.NewReplicator(client, f.ResyncPeriod, f.AllowAll)
+	secretRepl := secret.NewReplicator(client, f.ResyncPeriod, f.AllowAll, f.DisablePush)
+	configMapRepl := configmap.NewReplicator(client, f.ResyncPeriod, f.AllowAll, f.DisablePush)
+	roleRepl := role.NewReplicator(client, f.ResyncPeriod, f.AllowAll, f.DisablePush)
+	roleBindingRepl := rolebinding.NewReplicator(client, f.ResyncPeriod, f.AllowAll, f.DisablePush)
 
 	go secretRepl.Run()
 

--- a/replicate/configmap/configmaps.go
+++ b/replicate/configmap/configmaps.go
@@ -25,12 +25,13 @@ type Replicator struct {
 }
 
 // NewReplicator creates a new config map replicator
-func NewReplicator(client kubernetes.Interface, resyncPeriod time.Duration, allowAll bool) common.Replicator {
+func NewReplicator(client kubernetes.Interface, resyncPeriod time.Duration, allowAll, disablePush bool) common.Replicator {
 	repl := Replicator{
 		GenericReplicator: common.NewGenericReplicator(common.ReplicatorConfig{
 			Kind:         "ConfigMap",
 			ObjType:      &v1.ConfigMap{},
 			AllowAll:     allowAll,
+			DisablePush:  disablePush,
 			ResyncPeriod: resyncPeriod,
 			Client:       client,
 			ListFunc: func(lo metav1.ListOptions) (runtime.Object, error) {

--- a/replicate/role/roles.go
+++ b/replicate/role/roles.go
@@ -24,12 +24,13 @@ type Replicator struct {
 }
 
 // NewReplicator creates a new role replicator
-func NewReplicator(client kubernetes.Interface, resyncPeriod time.Duration, allowAll bool) common.Replicator {
+func NewReplicator(client kubernetes.Interface, resyncPeriod time.Duration, allowAll, disablePush bool) common.Replicator {
 	repl := Replicator{
 		GenericReplicator: common.NewGenericReplicator(common.ReplicatorConfig{
 			Kind:         "Role",
 			ObjType:      &rbacv1.Role{},
 			AllowAll:     allowAll,
+			DisablePush:  disablePush,
 			ResyncPeriod: resyncPeriod,
 			Client:       client,
 			ListFunc: func(lo metav1.ListOptions) (runtime.Object, error) {

--- a/replicate/role/roles_test.go
+++ b/replicate/role/roles_test.go
@@ -79,7 +79,7 @@ func TestRoleReplicator(t *testing.T) {
 	prefix := namespacePrefix()
 	client := kubernetes.NewForConfigOrDie(config)
 
-	repl := NewReplicator(client, 60*time.Second, false)
+	repl := NewReplicator(client, 60*time.Second, false, false)
 	go repl.Run()
 
 	time.Sleep(200 * time.Millisecond)

--- a/replicate/rolebinding/rolebindings.go
+++ b/replicate/rolebinding/rolebindings.go
@@ -26,12 +26,13 @@ type Replicator struct {
 const sleepTime = 100 * time.Millisecond
 
 // NewReplicator creates a new secret replicator
-func NewReplicator(client kubernetes.Interface, resyncPeriod time.Duration, allowAll bool) common.Replicator {
+func NewReplicator(client kubernetes.Interface, resyncPeriod time.Duration, allowAll, disablePush bool) common.Replicator {
 	repl := Replicator{
 		GenericReplicator: common.NewGenericReplicator(common.ReplicatorConfig{
 			Kind:         "RoleBinding",
 			ObjType:      &rbacv1.RoleBinding{},
 			AllowAll:     allowAll,
+			DisablePush:  disablePush,
 			ResyncPeriod: resyncPeriod,
 			Client:       client,
 			ListFunc: func(lo metav1.ListOptions) (runtime.Object, error) {

--- a/replicate/secret/secrets.go
+++ b/replicate/secret/secrets.go
@@ -25,12 +25,13 @@ type Replicator struct {
 }
 
 // NewReplicator creates a new secret replicator
-func NewReplicator(client kubernetes.Interface, resyncPeriod time.Duration, allowAll bool) common.Replicator {
+func NewReplicator(client kubernetes.Interface, resyncPeriod time.Duration, allowAll, disablePush bool) common.Replicator {
 	repl := Replicator{
 		GenericReplicator: common.NewGenericReplicator(common.ReplicatorConfig{
 			Kind:         "Secret",
 			ObjType:      &v1.Secret{},
 			AllowAll:     allowAll,
+			DisablePush:  disablePush,
 			ResyncPeriod: resyncPeriod,
 			Client:       client,
 			ListFunc: func(lo metav1.ListOptions) (runtime.Object, error) {

--- a/replicate/secret/secrets_test.go
+++ b/replicate/secret/secrets_test.go
@@ -80,7 +80,7 @@ func TestSecretReplicator(t *testing.T) {
 	prefix := namespacePrefix()
 	client := kubernetes.NewForConfigOrDie(config)
 
-	repl := NewReplicator(client, 60*time.Second, false)
+	repl := NewReplicator(client, 60*time.Second, false, false)
 	go repl.Run()
 
 	time.Sleep(200 * time.Millisecond)


### PR DESCRIPTION
Resolves #159

### Background

In Namespace as a Tenancy model, users can push resources to unauthorized namespaces.

### Changes

This commit lets operators decide to disable push-based replication by a `--disable-push` flag.

Signed-off-by: Sunghoon Kang <hoon@linecorp.com>