### PR TITLE
fix: Buildx fix for multiarch

### DIFF
--- a/Dockerfile.buildx
+++ b/Dockerfile.buildx
@@ -1,6 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.18 AS deps
-ARG TARGETPLATFORM
-ARG BUILDPLATFORM
+FROM golang:1.14 AS build
 
 COPY . /src
 WORKDIR /src
@@ -8,10 +6,7 @@ RUN go get -v ./...
 RUN go vet -v ./...
 RUN CGO_ENABLED=0 GO111MODULE=on go build
 
-FROM --platform=$TARGETPLATFORM scratch
-ARG TARGETPLATFORM
+FROM scratch
 LABEL MAINTAINER="Martin Helmich <m.helmich@mittwald.de>"
-
-COPY --from=build /src/ /kubernetes-replicator
-
+COPY --from=build /src/kubernetes-replicator /kubernetes-replicator
 CMD ["/kubernetes-replicator"]

--- a/Dockerfile.buildx
+++ b/Dockerfile.buildx
@@ -1,4 +1,4 @@
-FROM golang:1.14 AS build
+FROM golang:1.18 AS build
 
 COPY . /src
 WORKDIR /src


### PR DESCRIPTION
I had some issues building images that has multi-arch support.
This dockerfile worked out for me.

Since the releases are done with a separate image for each architecture, I needed to build my own image to have all architectures embedded in one single image.

This file will work with the command `docker buildx build -t foo/bar --platform "linux/arm64,linux/amd64" -f Dockerfile.buildx .`