### PR TITLE
fix: serviceaccounts access is needed for v2.9.0

### DIFF
--- a/deploy/helm-chart/kubernetes-replicator/templates/rbac.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/templates/rbac.yaml
@@ -22,7 +22,7 @@ rules:
     resources: [ "namespaces" ]
     verbs: [ "get", "watch", "list" ]
   - apiGroups: [""]
-    resources: ["secrets", "configmaps"]
+    resources: ["secrets", "configmaps", "serviceaccounts"]
     verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["roles", "rolebindings"]

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -13,7 +13,7 @@ rules:
   resources: [ "namespaces" ]
   verbs: [ "get", "watch", "list" ]
 - apiGroups: [""] # "" indicates the core API group
-  resources: ["secrets", "configmaps"]
+  resources: ["secrets", "configmaps", "serviceaccounts"]
   verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["roles", "rolebindings"]


### PR DESCRIPTION
After the support for serviceaccounts replication feature is added (https://github.com/mittwald/kubernetes-replicator/pull/249), the deployment will fail with error `kubernetes-replicator:kubernetes-replicator" cannot list resource "serviceaccounts" in API group "" at the cluster scope` This should be the default RBAC for new installs