### PR TITLE
Add support for enabling/disabling the replication of object types

### DIFF
--- a/config.go
+++ b/config.go
@@ -3,11 +3,16 @@ package main
 import "time"
 
 type flags struct {
-	Kubeconfig    string
-	ResyncPeriodS string
-	ResyncPeriod  time.Duration
-	StatusAddr    string
-	AllowAll      bool
-	LogLevel      string
-	LogFormat     string
+	Kubeconfig               string
+	ResyncPeriodS            string
+	ResyncPeriod             time.Duration
+	StatusAddr               string
+	AllowAll                 bool
+	LogLevel                 string
+	LogFormat                string
+	ReplicateSecrets         bool
+	ReplicateConfigMaps      bool
+	ReplicateRoles           bool
+	ReplicateRoleBindings    bool
+	ReplicateServiceAccounts bool
 }

--- a/deploy/helm-chart/kubernetes-replicator/templates/deployment.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/templates/deployment.yaml
@@ -43,7 +43,14 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            {{- toYaml .Values.args | nindent 12 }}
+            - -replicate-secrets={{ .Values.replicationEnabled.secrets }}
+            - -replicate-configmaps={{ .Values.replicationEnabled.configMaps }}
+            - -replicate-roles={{ .Values.replicationEnabled.roles }}
+            - -replicate-role-bindings={{ .Values.replicationEnabled.roleBindings }}
+            - -replicate-service-accounts={{ .Values.replicationEnabled.serviceAccounts }}
+            {{- with .Values.args }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: health
               containerPort: 9102

--- a/deploy/helm-chart/kubernetes-replicator/templates/rbac.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/templates/rbac.yaml
@@ -18,19 +18,69 @@ metadata:
   labels:
     {{- include "kubernetes-replicator.labels" . | nindent 4 }}
 rules:
-  - apiGroups: [ "" ]
-    resources: [ "namespaces" ]
-    verbs: [ "get", "watch", "list" ]
-  - apiGroups: [""]
-    resources: ["secrets", "configmaps", "serviceaccounts"]
-    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
-  - apiGroups: ["rbac.authorization.k8s.io"]
-    resources: ["roles", "rolebindings"]
-    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
+  - apiGroups:
+    - ""
+    resources:
+    - namespaces
+    verbs:
+    - get
+    - watch
+    - list
+{{ with .Values.replicationEnabled }}
+{{- if or .secrets .configMaps .serviceAccounts }}
+  - apiGroups:
+    - ""
+    resources:
+{{- if .secrets }}
+    - secrets
+{{- end }}
+{{- if .configMaps }}
+    - configmaps
+{{- end }}
+{{- if .serviceAccounts }}
+    - serviceaccounts
+{{- end }}
+    verbs:
+    - get
+    - watch
+    - list
+    - create
+    - update
+    - patch
+    - delete
+{{- end }}
+{{- if or .roles .roleBindings }}
+  - apiGroups:
+    - rbac.authorization.k8s.io
+    resources:
+{{- if .roles }}
+    - roles
+{{- end }}
+{{- if .roleBindings }}
+    - rolebindings
+{{- end }}
+    verbs:
+    - get
+    - watch
+    - list
+    - create
+    - update
+    - patch
+    - delete
+{{- end }}
+{{- end }}
 {{- range .Values.serviceAccount.privileges }}
   - apiGroups: {{ .apiGroups | toYaml | nindent 6 }}
     resources: {{ .resources | toYaml | nindent 6 }}
-    verbs: ["get", "watch", "list", "create", "update", "patch", "delete", "describe"]
+    verbs:
+    - get
+    - watch
+    - list
+    - create
+    - update
+    - patch
+    - delete
+    - describe
 {{- end }}
 ---
 kind: ClusterRoleBinding

--- a/deploy/helm-chart/kubernetes-replicator/values.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/values.yaml
@@ -7,14 +7,15 @@ nameOverride: ""
 fullnameOverride: ""
 grantClusterAdmin: false
 automountServiceAccountToken: true
-args: []
-  # - -resync-period=30m
-  # - -allow-all=false
-  # - -replicate-secrets=true
-  # - -replicate-configmaps=true
-  # - -replicate-roles=true
-  # - -replicate-role-bindings=true
-  # - -replicate-service-accounts=true
+# args:
+# - -resync-period=30m
+# - -allow-all=false
+replicationEnabled:
+  secrets: true
+  configMaps: true
+  roles: true
+  roleBindings: true
+  serviceAccounts: true
 
 ## Deployment strategy / DaemonSet updateStrategy
 ##

--- a/deploy/helm-chart/kubernetes-replicator/values.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/values.yaml
@@ -10,6 +10,11 @@ automountServiceAccountToken: true
 args: []
   # - -resync-period=30m
   # - -allow-all=false
+  # - -replicate-secrets=true
+  # - -replicate-configmaps=true
+  # - -replicate-roles=true
+  # - -replicate-role-bindings=true
+  # - -replicate-service-accounts=true
 
 ## Deployment strategy / DaemonSet updateStrategy
 ##

--- a/main.go
+++ b/main.go
@@ -31,6 +31,11 @@ func init() {
 	flag.StringVar(&f.LogLevel, "log-level", "info", "Log level (trace, debug, info, warn, error)")
 	flag.StringVar(&f.LogFormat, "log-format", "plain", "Log format (plain, json)")
 	flag.BoolVar(&f.AllowAll, "allow-all", false, "allow replication of all secrets (CAUTION: only use when you know what you're doing)")
+	flag.BoolVar(&f.ReplicateSecrets, "replicate-secrets", true, "Enable replication of secrets")
+	flag.BoolVar(&f.ReplicateConfigMaps, "replicate-configmaps", true, "Enable replication of config maps")
+	flag.BoolVar(&f.ReplicateRoles, "replicate-roles", true, "Enable replication of roles")
+	flag.BoolVar(&f.ReplicateRoleBindings, "replicate-role-bindings", true, "Enable replication of role bindings")
+	flag.BoolVar(&f.ReplicateServiceAccounts, "replicate-service-accounts", true, "Enable replication of service accounts")
 	flag.Parse()
 
 	switch strings.ToUpper(strings.TrimSpace(f.LogLevel)) {


### PR DESCRIPTION
This PR adds the support for enabling or disabling the replication of object types and strengthens the principle of least privilege. For example, you can now disable the replication of roles, role bindings or service accounts if thats not needed for your use case.

Fixes https://github.com/mittwald/kubernetes-replicator/issues/284