### PR TITLE
Fix service account name instead of chart release name

### DIFF
--- a/deploy/helm-chart/kubernetes-replicator/templates/rbac.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/templates/rbac.yaml
@@ -95,6 +95,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
-    name: {{ include "kubernetes-replicator.fullname" . }}
+    name: {{ include "kubernetes-replicator.serviceAccountName" . }}
     namespace: {{ .Release.Namespace | quote }}
 {{- end -}}


### PR DESCRIPTION
This PR provides a fix to the bug: https://github.com/mittwald/kubernetes-replicator/issues/344