### PR TITLE
Support `kind: Service` as resource

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: "1.20"
+          go-version: "1.22"
 
       - name: Compile
         run: go build .
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: "1.20"
+          go-version: "1.22"
 
       - uses: actions/checkout@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.20"
+          go-version: "1.22"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/Dockerfile.buildx
+++ b/Dockerfile.buildx
@@ -1,10 +1,9 @@
-FROM --platform=$BUILDPLATFORM golang:1.18 AS deps
+FROM --platform=$BUILDPLATFORM golang:1.22 AS build
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
 COPY . /src
 WORKDIR /src
-RUN go get -v ./...
 RUN go vet -v ./...
 RUN CGO_ENABLED=0 GO111MODULE=on go build
 
@@ -12,6 +11,6 @@ FROM --platform=$TARGETPLATFORM scratch
 ARG TARGETPLATFORM
 LABEL MAINTAINER="Martin Helmich <m.helmich@mittwald.de>"
 
-COPY --from=build /src/ /kubernetes-replicator
+COPY --from=build /src/kubernetes-replicator /replicator
 
-CMD ["/kubernetes-replicator"]
+CMD ["/replicator"]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ secrets and config maps available in multiple namespaces.
         1. [1. Create the source secret](#step-1-create-the-source-secret)
         1. [2. Create empty secret](#step-2-create-an-empty-destination-secret)
         1. [Special case: TLS secrets](#special-case-tls-secrets)
+   1. [Special case: Service replication](#special-case-service-replication) 
+1. [Local development/testing](#local-developmenttesting-with-minikube) 
 
 ## Deployment
 
@@ -110,6 +112,11 @@ There are two general methods for push-based replication:
 When the labels of a namespace are changed, any resources that were replicated by labels into the namespace and no longer qualify for replication under the new set of labels will be deleted. Afterwards any resources that now match the updated labels will be replicated into the namespace.
 
 It is possible to use both methods of push-based replication together in a single resource, by specifying both annotations.
+
+#### :warning: "push-based" is dangerous
+:warning: "push-based" setup is dangerous as it allows an actor to influence (read: overwrite) sensitive resources in a cluster.
+
+Please consider to only enable the features you actually need - see `values.yaml:replicationEnabled[]`.
 
 ### "Pull-based" replication
 
@@ -241,3 +248,69 @@ data:
 ```
 
 See also: https://github.com/mittwald/kubernetes-replicator/issues/120
+
+### Special case: Service replication
+
+An annotated `kind: Service` will be replicated to another namespace as `type: ExternalName`. This feature allows to cover 2 use cases
+
+1) common DNS domain for services or a very lightweight service mesh
+2) migration of services into own namespaces while keeping their known DNS names
+
+
+This service
+ ```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: source-service
+  namespace: default
+  annotations:
+    alb.ingress.kubernetes.io/backend-protocol: HTTP
+    alb.ingress.kubernetes.io/healthcheck-path: /version
+    alb.ingress.kubernetes.io/healthcheck-protocol: HTTP
+    replicator.v1.mittwald.de/replicate-to: some-namespace
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP
+  selector:
+    app: foo
+    application: foo
+```
+
+will be replicated to this
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: source-service
+  namespace: some-namespace
+  annotations:
+    replicator.v1.mittwald.de/replicated-at: "2024-08-21T09:07:45Z"
+    replicator.v1.mittwald.de/replicated-from-version: "680"
+spec:
+  type: ExternalName
+  externalName: source-service.default.svc.cluster.local.
+  sessionAffinity: None
+```
+
+Please note:
+- `metadata.annotations` are **not replicated** by default as on a `kind: service` they usually drive load-balancer operators. You can explicitly set `replicator.v1.mittwald.de/strip-annotations: "false"` to keep them.
+- there is only the `replicator.v1.mittwald.de/replicate-to` option implemented
+- pre-existing target `kind: Service` will happily be patched/overwritten ;-)
+
+## Local development/testing with minikube
+- start a minikube cluster
+  - `minikube start --kubernetes-version=latest`
+- build the image (adjust your platform)
+  - `minikube image build -t quay.io/mittwald/kubernetes-replicator:latest -f Dockerfile.buildx --build-env=TARGETPLATFORM=linux/amd64 --build-env=BUILDPLATFORM=linux/amd64 .`
+  - `minikube image ls`
+- deploy replicator
+  - `kubectl apply -f deploy/rbac.yaml`
+  - `kubectl apply -f deploy/deployment.yaml`
+  - `kubectl get pods -n kube-system`
+- deploy test sources
+  - `kubectl apply --kustomize test` 
+- happy replication!

--- a/config.go
+++ b/config.go
@@ -14,5 +14,6 @@ type flags struct {
 	ReplicateConfigMaps      bool
 	ReplicateRoles           bool
 	ReplicateRoleBindings    bool
+	ReplicateServices        bool
 	ReplicateServiceAccounts bool
 }

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       - name: kubernetes-replicator
         securityContext: {}
         image: quay.io/mittwald/kubernetes-replicator:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         args: []
         ports:
         - name: health

--- a/deploy/helm-chart/kubernetes-replicator/Chart.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/Chart.yaml
@@ -4,6 +4,6 @@ description: Controller for replicating secrets+configmaps across namespaces
 
 type: application
 
-version: 2.10.1
+version: 2.10.2
 
-appVersion: v2.10.1
+appVersion: v2.10.2

--- a/deploy/helm-chart/kubernetes-replicator/templates/deployment.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/templates/deployment.yaml
@@ -48,6 +48,7 @@ spec:
             - -replicate-roles={{ .Values.replicationEnabled.roles }}
             - -replicate-role-bindings={{ .Values.replicationEnabled.roleBindings }}
             - -replicate-service-accounts={{ .Values.replicationEnabled.serviceAccounts }}
+            - -replicate-services={{ .Values.replicationEnabled.services }}
             {{- with .Values.args }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/deploy/helm-chart/kubernetes-replicator/templates/rbac.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/templates/rbac.yaml
@@ -40,6 +40,9 @@ rules:
 {{- if .serviceAccounts }}
     - serviceaccounts
 {{- end }}
+{{- if .services }}
+    - services
+{{- end }}
     verbs:
     - get
     - watch

--- a/deploy/helm-chart/kubernetes-replicator/templates/rbac.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/templates/rbac.yaml
@@ -27,7 +27,7 @@ rules:
     - watch
     - list
 {{ with .Values.replicationEnabled }}
-{{- if or .secrets .configMaps .serviceAccounts }}
+{{- if or .secrets .configMaps .serviceAccounts .services }}
   - apiGroups:
     - ""
     resources:

--- a/deploy/helm-chart/kubernetes-replicator/values.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: quay.io/mittwald/kubernetes-replicator
   #tag: stable # if no tag is given, the chart's appVersion is used
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
@@ -16,6 +16,7 @@ replicationEnabled:
   roles: true
   roleBindings: true
   serviceAccounts: true
+  services: true
 
 ## Deployment strategy / DaemonSet updateStrategy
 ##

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -13,7 +13,7 @@ rules:
   resources: [ "namespaces" ]
   verbs: [ "get", "watch", "list" ]
 - apiGroups: [""] # "" indicates the core API group
-  resources: ["secrets", "configmaps", "serviceaccounts"]
+  resources: ["secrets", "configmaps", "serviceaccounts", "services"]
   verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["roles", "rolebindings"]

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/mittwald/kubernetes-replicator
 
 go 1.22
 
-toolchain go1.22.5
-
 require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/mittwald/kubernetes-replicator
 
-go 1.20
+go 1.22
+
+toolchain go1.22.5
 
 require (
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,7 @@ github.com/go-openapi/jsonreference v0.20.2/go.mod h1:Bl1zwGIM8/wsvqjsOQLJ/SH+En
 github.com/go-openapi/swag v0.22.3 h1:yMBqmnQ0gyZvEb/+KzuWZOXgllrXT4SADYbvDaXHv/g=
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
+github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -27,6 +28,7 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
+github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
@@ -43,6 +45,7 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -57,12 +60,15 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/onsi/ginkgo/v2 v2.13.0 h1:0jY9lJquiL8fcf3M4LAXN5aMlS/b2BV86HFFPCPMgE4=
+github.com/onsi/ginkgo/v2 v2.13.0/go.mod h1:TE309ZR8s5FsKKpuB1YAQYBzCaAfUgatB/xlT/ETL/o=
 github.com/onsi/gomega v1.29.0 h1:KIA/t2t5UBzoirT4H9tsML45GEbo3ouUnBHsCfD2tVg=
+github.com/onsi/gomega v1.29.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
@@ -116,6 +122,7 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.16.1 h1:TLyB3WofjdOEepBHAU20JdNC1Zbg87elYofWYAY5oZA=
+golang.org/x/tools v0.16.1/go.mod h1:kYVVN6I1mBNoB1OX+noeBjbRk4IUEPa7JJ+TJMEooJ0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mittwald/kubernetes-replicator/replicate/role"
 	"github.com/mittwald/kubernetes-replicator/replicate/rolebinding"
 	"github.com/mittwald/kubernetes-replicator/replicate/secret"
+	"github.com/mittwald/kubernetes-replicator/replicate/service"
 	"github.com/mittwald/kubernetes-replicator/replicate/serviceaccount"
 
 	log "github.com/sirupsen/logrus"
@@ -36,6 +37,7 @@ func init() {
 	flag.BoolVar(&f.ReplicateRoles, "replicate-roles", true, "Enable replication of roles")
 	flag.BoolVar(&f.ReplicateRoleBindings, "replicate-role-bindings", true, "Enable replication of role bindings")
 	flag.BoolVar(&f.ReplicateServiceAccounts, "replicate-service-accounts", true, "Enable replication of service accounts")
+	flag.BoolVar(&f.ReplicateServices, "replicate-services", true, "Enable replication of services")
 	flag.Parse()
 
 	switch strings.ToUpper(strings.TrimSpace(f.LogLevel)) {
@@ -115,6 +117,12 @@ func main() {
 		serviceAccountRepl := serviceaccount.NewReplicator(client, f.ResyncPeriod, f.AllowAll)
 		go serviceAccountRepl.Run()
 		enabledReplicators = append(enabledReplicators, serviceAccountRepl)
+	}
+
+	if f.ReplicateServices {
+		serviceRepl := service.NewReplicator(client, f.ResyncPeriod, f.AllowAll)
+		go serviceRepl.Run()
+		enabledReplicators = append(enabledReplicators, serviceRepl)
 	}
 
 	h := liveness.Handler{

--- a/replicate/common/consts.go
+++ b/replicate/common/consts.go
@@ -12,4 +12,5 @@ const (
 	ReplicateToMatching             = "replicator.v1.mittwald.de/replicate-to-matching"
 	KeepOwnerReferences             = "replicator.v1.mittwald.de/keep-owner-references"
 	StripLabels                     = "replicator.v1.mittwald.de/strip-labels"
+	StripAnnotations                = "replicator.v1.mittwald.de/strip-annotations"
 )

--- a/replicate/common/generic_sync_map.go
+++ b/replicate/common/generic_sync_map.go
@@ -1,0 +1,44 @@
+package common
+
+import (
+	"sync"
+)
+
+// GenericMap is a generic sync.Map that can store any type of key and value.
+type GenericMap[K comparable, V any] struct {
+	m sync.Map
+}
+
+func (gm *GenericMap[K, V]) Store(key K, value V) {
+	gm.m.Store(key, value)
+}
+
+func (gm *GenericMap[K, V]) Load(key K) (value V, ok bool) {
+	rawValue, ok := gm.m.Load(key)
+	if ok {
+		value = rawValue.(V)
+	}
+	return value, ok
+}
+
+func (gm *GenericMap[K, V]) LoadOrStore(key K, value V) (actual V, loaded bool) {
+	rawActual, loaded := gm.m.LoadOrStore(key, value)
+	if loaded {
+		actual = rawActual.(V)
+	} else {
+		actual = value
+	}
+	return actual, loaded
+}
+
+func (gm *GenericMap[K, V]) Delete(key K) {
+	gm.m.Delete(key)
+}
+
+func (gm *GenericMap[K, V]) Range(f func(key K, value V) bool) {
+	gm.m.Range(func(rawKey, rawValue any) bool {
+		key := rawKey.(K)
+		value := rawValue.(V)
+		return f(key, value)
+	})
+}

--- a/replicate/service/services.go
+++ b/replicate/service/services.go
@@ -1,0 +1,235 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/mittwald/kubernetes-replicator/replicate/common"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+)
+
+type Replicator struct {
+	*common.GenericReplicator
+}
+
+// NewReplicator creates a new service replicator
+func NewReplicator(client kubernetes.Interface, resyncPeriod time.Duration, allowAll bool) common.Replicator {
+	repl := Replicator{
+		GenericReplicator: common.NewGenericReplicator(common.ReplicatorConfig{
+			Kind:         "Service",
+			ObjType:      &corev1.Service{},
+			AllowAll:     allowAll,
+			ResyncPeriod: resyncPeriod,
+			Client:       client,
+			ListFunc: func(lo metav1.ListOptions) (runtime.Object, error) {
+				return client.CoreV1().Services("").List(context.TODO(), lo)
+			},
+			WatchFunc: func(lo metav1.ListOptions) (watch.Interface, error) {
+				return client.CoreV1().Services("").Watch(context.TODO(), lo)
+			},
+		}),
+	}
+	repl.UpdateFuncs = common.UpdateFuncs{
+		ReplicateObjectTo:        repl.ReplicateObjectTo,
+		PatchDeleteDependent:     repl.PatchDeleteDependent,
+		DeleteReplicatedResource: repl.DeleteReplicatedResource,
+	}
+
+	return &repl
+}
+
+// ReplicateObjectTo copies the whole object to target namespace
+func (r *Replicator) ReplicateObjectTo(sourceObj interface{}, target *v1.Namespace) error {
+	source := sourceObj.(*corev1.Service)
+	targetLocation := fmt.Sprintf("%s/%s", target.Name, source.Name)
+
+	logger := log.
+		WithField("kind", r.Kind).
+		WithField("source", common.MustGetKey(source)).
+		WithField("target", targetLocation)
+
+	targetResource, exists, err := r.Store.GetByKey(targetLocation)
+	if err != nil {
+		return errors.Wrapf(err, "Could not get %s from cache!", targetLocation)
+	}
+	logger.Infof("Checking if %s exists? %v", targetLocation, exists)
+
+	var targetCopy *corev1.Service
+	if exists {
+		targetObject := targetResource.(*corev1.Service)
+		targetVersion, ok := targetObject.Annotations[common.ReplicatedFromVersionAnnotation]
+		sourceVersion := source.ResourceVersion
+
+		if ok && targetVersion == sourceVersion {
+			logger.Debugf("Service %s is already up-to-date", common.MustGetKey(targetObject))
+			return nil
+		}
+
+		targetCopy = targetObject.DeepCopy()
+	} else {
+		targetCopy = new(corev1.Service)
+	}
+
+	keepOwnerReferences, ok := source.Annotations[common.KeepOwnerReferences]
+	if ok && keepOwnerReferences == "true" {
+		targetCopy.OwnerReferences = source.OwnerReferences
+	}
+
+	if targetCopy.Annotations == nil {
+		targetCopy.Annotations = make(map[string]string)
+	}
+
+	labelsCopy := make(map[string]string)
+
+	stripLabels, ok := source.Annotations[common.StripLabels]
+	if !ok && stripLabels != "true" {
+		if source.Labels != nil {
+			for key, value := range source.Labels {
+				labelsCopy[key] = value
+			}
+		}
+	}
+
+	annotationsCopy := make(map[string]string)
+	// we strip annotations by default as they usually contain data for eg. loadbalancer controllers
+	// a user has to set `"replicator.v1.mittwald.de/ strip-annotations = false"` to keep them
+	stripAnnotations, ok := source.Annotations[common.StripAnnotations]
+	if ok && stripAnnotations == "false" {
+		if source.Annotations != nil {
+			for key, value := range source.Annotations {
+				annotationsCopy[key] = value
+			}
+		}
+	}
+
+	// we clean out .Spec and set our own
+	newSpec := new(corev1.ServiceSpec)
+	newSpec.Type = corev1.ServiceTypeExternalName
+
+	// Get the full DNS name of the source service as cluster domains can vary
+	serviceFQDN, err := getFullDNSName(source.Name, source.Namespace)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to get DNS name for service %s/%s", source.Namespace, source.Name)
+	}
+	logger.Debugf("Resolved existing service %s/%s to %s", target.Name, targetCopy.Name, serviceFQDN)
+
+	newSpec.ExternalName = serviceFQDN
+	targetCopy.Name = source.Name
+	targetCopy.Labels = labelsCopy
+	targetCopy.Spec = *newSpec
+	targetCopy.Annotations = annotationsCopy
+	targetCopy.Annotations[common.ReplicatedAtAnnotation] = time.Now().Format(time.RFC3339)
+	targetCopy.Annotations[common.ReplicatedFromVersionAnnotation] = source.ResourceVersion
+
+	var obj interface{}
+
+	if exists {
+		if err == nil {
+			logger.Debugf("Updating existing service %s/%s", target.Name, targetCopy.Name)
+			obj, err = r.Client.CoreV1().Services(target.Name).Update(context.TODO(), targetCopy, metav1.UpdateOptions{})
+		}
+	} else {
+		if err == nil {
+			logger.Debugf("Creating a new service %s/%s", target.Name, targetCopy.Name)
+			obj, err = r.Client.CoreV1().Services(target.Name).Create(context.TODO(), targetCopy, metav1.CreateOptions{})
+		}
+	}
+	if err != nil {
+		return errors.Wrapf(err, "Failed to update service %s/%s", target.Name, targetCopy.Name)
+	}
+
+	if err := r.Store.Update(obj); err != nil {
+		return errors.Wrapf(err, "Failed to update cache for %s/%s", target.Name, targetCopy)
+	}
+
+	return nil
+}
+
+func (r *Replicator) PatchDeleteDependent(sourceKey string, target interface{}) (interface{}, error) {
+	dependentKey := common.MustGetKey(target)
+	logger := log.WithFields(log.Fields{
+		"kind":   r.Kind,
+		"source": sourceKey,
+		"target": dependentKey,
+	})
+
+	targetObject, ok := target.(*corev1.Service)
+	if !ok {
+		err := errors.Errorf("bad type returned from Store: %T", target)
+		return nil, err
+	}
+
+	patch := []common.JSONPatchOperation{{Operation: "remove", Path: "/imagePullSecrets"}}
+	patchBody, err := json.Marshal(&patch)
+
+	if err != nil {
+		return nil, errors.Wrapf(err, "error while building patch body for service %s: %v", dependentKey, err)
+
+	}
+
+	logger.Debugf("clearing dependent service %s", dependentKey)
+	logger.Tracef("patch body: %s", string(patchBody))
+
+	s, err := r.Client.CoreV1().Services(targetObject.Namespace).Patch(context.TODO(), targetObject.Name, types.JSONPatchType, patchBody, metav1.PatchOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "error while patching service %s: %v", dependentKey, err)
+	}
+	return s, nil
+}
+
+// DeleteReplicatedResource deletes a resource replicated by ReplicateTo annotation
+func (r *Replicator) DeleteReplicatedResource(targetResource interface{}) error {
+	targetLocation := common.MustGetKey(targetResource)
+	logger := log.WithFields(log.Fields{
+		"kind":   r.Kind,
+		"target": targetLocation,
+	})
+
+	object := targetResource.(*corev1.Service)
+	logger.Debugf("Deleting %s", targetLocation)
+	if err := r.Client.CoreV1().Services(object.Namespace).Delete(context.TODO(), object.Name, metav1.DeleteOptions{}); err != nil {
+		return errors.Wrapf(err, "Failed deleting %s: %v", targetLocation, err)
+	}
+	return nil
+}
+
+// Function to determine the full DNS name of the service
+func getFullDNSName(serviceName, namespace string) (string, error) {
+	// Perform DNS lookup to get the IP address of the service
+	ips, err := net.LookupHost(fmt.Sprintf("%s.%s", serviceName, namespace))
+	if err != nil {
+		// Return an empty string and the error if DNS lookup fails
+		return "", err
+	}
+
+	// Check if the lookup returned at least one IP address
+	if len(ips) == 0 {
+		return "", fmt.Errorf("DNS lookup returned empty result")
+	}
+
+	// Perform reverse DNS lookup to get the full DNS name of the IP address
+	names, err := net.LookupAddr(ips[0])
+	if err != nil {
+		return "", err
+	}
+
+	// Check if the reverse lookup returned at least one name
+	if len(names) == 0 {
+		return "", fmt.Errorf("reverse DNS lookup returned empty result")
+	}
+
+	// Return the first name from the reverse lookup result
+	return names[0], nil
+}

--- a/test/configmap_source.yaml
+++ b/test/configmap_source.yaml
@@ -4,3 +4,12 @@ metadata:
   name: config-source
 data:
   foo: bar
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-source-replicate-to
+  annotations:
+    replicator.v1.mittwald.de/replicate-to: some-namespace
+data:
+  bar: foo

--- a/test/kustomization.yaml
+++ b/test/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - configmap_reference.yaml
+  - configmap_source.yaml
+  - secret_reference.yaml
+  - secret_source.yaml
+  - service_source.yaml

--- a/test/secret_source.yaml
+++ b/test/secret_source.yaml
@@ -2,5 +2,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: source-secret
+  annotations:
+    # replicator.v1.mittwald.de/replication-allowed: "true"
+    # replicator.v1.mittwald.de/replication-allowed-namespaces: some-namespace
+    replicator.v1.mittwald.de/replicate-to: some-namespace
 data:
   value: SGFsbG8gV2VsdA==

--- a/test/service_source.yaml
+++ b/test/service_source.yaml
@@ -1,0 +1,35 @@
+## this is the target but already exists
+#apiVersion: v1
+#kind: Service
+#metadata:
+#  name: source-service
+#  namespace: some-namespace
+#spec:
+#  ports:
+#    - name: http
+#      port: 80
+#      targetPort: http
+#      protocol: TCP
+#  selector:
+#    app: foo
+#    application: foo
+#---
+apiVersion: v1
+kind: Service
+metadata:
+  name: source-service
+  namespace: default
+  annotations:
+    alb.ingress.kubernetes.io/backend-protocol: HTTP
+    alb.ingress.kubernetes.io/healthcheck-path: /version
+    alb.ingress.kubernetes.io/healthcheck-protocol: HTTP
+    replicator.v1.mittwald.de/replicate-to: some-namespace
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP
+  selector:
+    app: foo
+    application: foo


### PR DESCRIPTION
With this PR the replicator supports annotated `kind: Service` which will be replicated to another namespace as `type: ExternalName`. This feature allows to cover 2 use cases

1) common DNS domain for services or a very lightweight service mesh
2) migration of services into own namespaces while keeping their known DNS names

Please note:
- `metadata.annotations` are **not replicated** by default as on a `kind: service` they usually drive load-balancer operators. You can explicitly set `replicator.v1.mittwald.de/strip-annotations: "false"` to keep them.
- there is only the `replicator.v1.mittwald.de/replicate-to` option implemented
- pre-existing target `kind: Service` will happily be patched/overwritten ;-)

---
Thanks for the very clean code and ease of extensibility which comes with it. Much appreciated :pray: 