### PR TITLE
Fix concurrent map access by using a synchronized map

### DIFF
--- a/replicate/common/generic_sync_map.go
+++ b/replicate/common/generic_sync_map.go
@@ -1,0 +1,44 @@
+package common
+
+import (
+	"sync"
+)
+
+// GenericMap is a generic sync.Map that can store any type of key and value.
+type GenericMap[K comparable, V any] struct {
+	m sync.Map
+}
+
+func (gm *GenericMap[K, V]) Store(key K, value V) {
+	gm.m.Store(key, value)
+}
+
+func (gm *GenericMap[K, V]) Load(key K) (value V, ok bool) {
+	rawValue, ok := gm.m.Load(key)
+	if ok {
+		value = rawValue.(V)
+	}
+	return value, ok
+}
+
+func (gm *GenericMap[K, V]) LoadOrStore(key K, value V) (actual V, loaded bool) {
+	rawActual, loaded := gm.m.LoadOrStore(key, value)
+	if loaded {
+		actual = rawActual.(V)
+	} else {
+		actual = value
+	}
+	return actual, loaded
+}
+
+func (gm *GenericMap[K, V]) Delete(key K) {
+	gm.m.Delete(key)
+}
+
+func (gm *GenericMap[K, V]) Range(f func(key K, value V) bool) {
+	gm.m.Range(func(rawKey, rawValue any) bool {
+		key := rawKey.(K)
+		value := rawValue.(V)
+		return f(key, value)
+	})
+}


### PR DESCRIPTION
Fixes #216

Copy'ing the analysis from the issue here:

- There is a [global Namespace informer](https://github.com/mittwald/kubernetes-replicator/blob/master/replicate/common/namespaces.go#L18). The `generic_replicator` uses it to [register](https://github.com/mittwald/kubernetes-replicator/blob/master/replicate/common/generic-replicator.go#L81-L82) hook functions to be informed on namespace additions and updates.
- The `generic_replicator` also uses its [own informer](https://github.com/mittwald/kubernetes-replicator/blob/master/replicate/common/generic-replicator.go#L67) to be notified of changes to other resources.
- Our understanding is that the functions that the Informers call, are called in dedicated Go routines.
- The same map is [iterated](https://github.com/mittwald/kubernetes-replicator/blob/master/replicate/common/generic-replicator.go#L153) from the `NamespaceAdded` hook as well as [written](https://github.com/mittwald/kubernetes-replicator/blob/master/replicate/common/generic-replicator.go#L270) from the `ResourceAdded` hook called by the other Informer.

We switched to using a `sync.Map` for `ReplicateToList` and `ReplicateToMatchingList`.
We did not change the `DependencyMap`, since it is only used in the resources informer hooks.

We also created a simple test to see whether there is any noticeable change to the performance:
- Create a `fake.NewClientset()` K8s client
- Create a test secret that is push replicated via a pattern
- Create 1000 test namespaces
- Measure the time until the replication is finished.

We did not see any change in the execution time. But of course this test may not be extensive, so any insights are appreciated.
