### PR TITLE
feat: ability to add deployment labels and annotations

### DIFF
--- a/deploy/helm-chart/kubernetes-replicator/Chart.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/Chart.yaml
@@ -4,6 +4,6 @@ description: Controller for replicating secrets+configmaps across namespaces
 
 type: application
 
-version: 2.10.2
+version: 2.10.3
 
 appVersion: v2.10.2

--- a/deploy/helm-chart/kubernetes-replicator/Chart.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/Chart.yaml
@@ -4,6 +4,6 @@ description: Controller for replicating secrets+configmaps across namespaces
 
 type: application
 
-version: 2.10.3
+version: 2.10.2
 
 appVersion: v2.10.2

--- a/deploy/helm-chart/kubernetes-replicator/templates/deployment.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/templates/deployment.yaml
@@ -4,6 +4,13 @@ metadata:
   name: {{ include "kubernetes-replicator.fullname" . }}
   labels:
     {{- include "kubernetes-replicator.labels" . | nindent 4 }}
+    {{- if .Values.labels }}
+    {{- toYaml .Values.labels | nindent 4 }}
+    {{- end }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: 1
   {{- with .Values.updateStrategy }}

--- a/deploy/helm-chart/kubernetes-replicator/values.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/values.yaml
@@ -59,9 +59,17 @@ tolerations: []
 
 affinity: {}
 
-podLabels: {}
+# Deployment annotations
+annotations: {}
 
+# Deployment labels
+labels: {}
+
+# Pod annotations
 podAnnotations: {}
+
+# Pod labels
+podLabels: {}
 
 livenessProbe:
   initialDelaySeconds: 60


### PR DESCRIPTION
Hi,

This PR adds the ability to specify custom labels and annotations for the deployment in the Helm chart.

Thanks