### PR TITLE
feat(deploy/helm): add value option to override release namespace

### DIFF
--- a/deploy/helm-chart/kubernetes-replicator/templates/_helpers.tpl
+++ b/deploy/helm-chart/kubernetes-replicator/templates/_helpers.tpl
@@ -32,6 +32,13 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Create namespace used by the chart, defaulting to helm release namespace
+*/}}
+{{- define "kubernetes-replicator.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "kubernetes-replicator.labels" -}}

--- a/deploy/helm-chart/kubernetes-replicator/templates/deployment.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kubernetes-replicator.fullname" . }}
+  namespace: {{ include "kubernetes-replicator.namespace" . | quote }}
   labels:
     {{- include "kubernetes-replicator.labels" . | nindent 4 }}
     {{- if .Values.labels }}

--- a/deploy/helm-chart/kubernetes-replicator/templates/rbac.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/templates/rbac.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kubernetes-replicator.serviceAccountName" . }}
+  namespace: {{ include "kubernetes-replicator.namespace" . | quote }}
   labels:
     {{- include "kubernetes-replicator.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
@@ -15,6 +16,7 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "kubernetes-replicator.fullname" . }}
+  namespace: {{ include "kubernetes-replicator.namespace" . | quote }}
   labels:
     {{- include "kubernetes-replicator.labels" . | nindent 4 }}
 rules:
@@ -87,6 +89,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "kubernetes-replicator.fullname" . }}
+  namespace: {{ include "kubernetes-replicator.namespace" . | quote }}
   labels:
     {{- include "kubernetes-replicator.labels" . | nindent 4 }}
 roleRef:
@@ -96,5 +99,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "kubernetes-replicator.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
+    namespace: {{ include "kubernetes-replicator.namespace" . | quote }}
 {{- end -}}

--- a/deploy/helm-chart/kubernetes-replicator/values.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/values.yaml
@@ -5,6 +5,7 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+namespaceOverride: ""
 grantClusterAdmin: false
 automountServiceAccountToken: true
 # args:


### PR DESCRIPTION
Actually there's a limitation when using subcharts in helm, the namespace can't be overridden when calling the subchart (see: https://github.com/helm/helm/issues/5358).

In my case I want to add a dependency on a global chart that will deploy the Kubernetes-replicator chart.
But the actually management of Kubernetes replicator namespace doesn't allow me to define another namespace than the one defined in the release of the main chart.

That's why I propose with this PR to implement a "namespaceOverride" value that can be set if someone (like me) wants to use another value than the helm release namespace.