### PR TITLE
add ability to attach volumes to deployment

### DIFF
--- a/deploy/helm-chart/kubernetes-replicator/templates/deployment.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/templates/deployment.yaml
@@ -82,6 +82,8 @@ spec:
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+      {{- toYaml .Values.volumes | nindent 6 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm-chart/kubernetes-replicator/values.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/values.yaml
@@ -84,3 +84,6 @@ readinessProbe:
   timeoutSeconds: 1
   failureThreshold: 3
   successThreshold: 1
+
+# Allow volumes to mount service account token manually if someone needs it
+volumes: []


### PR DESCRIPTION
Add the ability to attach volumes manually, this is needed for service account tokens 
you can read more here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#launch-a-pod-using-service-account-token-projection