### PR TITLE
Make the service account privileges dynamic i.e. not hardcoded

### DIFF
--- a/deploy/helm-chart/kubernetes-replicator/templates/rbac.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/templates/rbac.yaml
@@ -23,7 +23,7 @@ rules:
     resources:
     - namespaces
     verbs:
-    - get
+    - get 
     - watch
     - list
 {{ with .Values.replicationEnabled }}
@@ -40,14 +40,7 @@ rules:
 {{- if .serviceAccounts }}
     - serviceaccounts
 {{- end }}
-    verbs:
-    - get
-    - watch
-    - list
-    - create
-    - update
-    - patch
-    - delete
+    verbs:  {{ .privileges | toYaml | nindent 4 }}
 {{- end }}
 {{- if or .roles .roleBindings }}
   - apiGroups:
@@ -70,17 +63,9 @@ rules:
 {{- end }}
 {{- end }}
 {{- range .Values.serviceAccount.privileges }}
-  - apiGroups: {{ .apiGroups | toYaml | nindent 6 }}
-    resources: {{ .resources | toYaml | nindent 6 }}
-    verbs:
-    - get
-    - watch
-    - list
-    - create
-    - update
-    - patch
-    - delete
-    - describe
+  - apiGroups: {{ .apiGroups | toYaml | nindent 4 }}
+    resources: {{ .resources | toYaml | nindent 4 }}
+    verbs: {{ .privileges | toYaml | nindent 4 }}
 {{- end }}
 ---
 kind: ClusterRoleBinding

--- a/deploy/helm-chart/kubernetes-replicator/values.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/values.yaml
@@ -16,6 +16,14 @@ replicationEnabled:
   roles: true
   roleBindings: true
   serviceAccounts: true
+  privileges:
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - patch
+  - delete 
 
 ## Deployment strategy / DaemonSet updateStrategy
 ##


### PR DESCRIPTION
In this PR I have suggested to make the privileges i.e. the verbs/actions that the clusterRole assigned to the service account ```variable and dynamic``` not hardcoded.

Why do we need this change? for example if you want the replicator service account to read from all namespaces but just replicate/push to a specific namespace(s) *- by creating a rolebinding for this namespace(s) -* not for the whole cluster. Also it can be considered as a good security practice where making a service account do anything in the clusterRole, isn't recommended at all.

So I have made the ability to restrict the privileges assigned to the service account.

I need your opinion to resume working on this feature :)

I have mentioned my proposal here in this [issue](https://github.com/mittwald/kubernetes-replicator/issues/193) and decided to make it real :)