### PR TITLE
feat: add --exclude-namespaces flag to skip replication in specified namespaces

### DIFF
--- a/config.go
+++ b/config.go
@@ -16,4 +16,5 @@ type flags struct {
 	ReplicateRoleBindings    bool
 	ReplicateServiceAccounts bool
 	SyncByContent            bool
+	ExcludeNamespaces        string
 }

--- a/replicate/common/exclude.go
+++ b/replicate/common/exclude.go
@@ -1,0 +1,36 @@
+package common
+
+import (
+	"regexp"
+)
+
+type NamespaceFilter struct {
+	ExcludePatterns []string
+	compiled        []*regexp.Regexp
+}
+
+func NewNamespaceFilter(patterns []string) *NamespaceFilter {
+	var compiled []*regexp.Regexp
+	for _, pat := range patterns {
+		if pat == "" {
+			continue
+		}
+		re, err := regexp.Compile(pat)
+		if err == nil {
+			compiled = append(compiled, re)
+		}
+	}
+	return &NamespaceFilter{
+		ExcludePatterns: patterns,
+		compiled:        compiled,
+	}
+}
+
+func (f *NamespaceFilter) ShouldExclude(namespace string) bool {
+	for _, re := range f.compiled {
+		if re.MatchString(namespace) {
+			return true
+		}
+	}
+	return false
+}

--- a/replicate/configmap/configmaps.go
+++ b/replicate/configmap/configmaps.go
@@ -26,7 +26,7 @@ type Replicator struct {
 }
 
 // NewReplicator creates a new config map replicator
-func NewReplicator(client kubernetes.Interface, resyncPeriod time.Duration, allowAll, syncByContent bool) common.Replicator {
+func NewReplicator(client kubernetes.Interface, resyncPeriod time.Duration, allowAll, syncByContent bool, namespaceFilter *common.NamespaceFilter) common.Replicator {
 	repl := Replicator{
 		GenericReplicator: common.NewGenericReplicator(common.ReplicatorConfig{
 			Kind:          "ConfigMap",
@@ -41,6 +41,7 @@ func NewReplicator(client kubernetes.Interface, resyncPeriod time.Duration, allo
 			WatchFunc: func(lo metav1.ListOptions) (watch.Interface, error) {
 				return client.CoreV1().ConfigMaps("").Watch(context.TODO(), lo)
 			},
+			NamespaceFilter: namespaceFilter,
 		}),
 	}
 	repl.UpdateFuncs = common.UpdateFuncs{

--- a/replicate/secret/secrets.go
+++ b/replicate/secret/secrets.go
@@ -26,7 +26,7 @@ type Replicator struct {
 }
 
 // NewReplicator creates a new secret replicator
-func NewReplicator(client kubernetes.Interface, resyncPeriod time.Duration, allowAll, syncByContent bool) common.Replicator {
+func NewReplicator(client kubernetes.Interface, resyncPeriod time.Duration, allowAll, syncByContent bool, namespaceFilter *common.NamespaceFilter) common.Replicator {
 	repl := Replicator{
 		GenericReplicator: common.NewGenericReplicator(common.ReplicatorConfig{
 			Kind:          "Secret",
@@ -41,6 +41,7 @@ func NewReplicator(client kubernetes.Interface, resyncPeriod time.Duration, allo
 			WatchFunc: func(lo metav1.ListOptions) (watch.Interface, error) {
 				return client.CoreV1().Secrets("").Watch(context.TODO(), lo)
 			},
+			NamespaceFilter: namespaceFilter,
 		}),
 	}
 	repl.UpdateFuncs = common.UpdateFuncs{

--- a/replicate/secret/secrets_test.go
+++ b/replicate/secret/secrets_test.go
@@ -82,8 +82,9 @@ func TestSecretReplicator(t *testing.T) {
 	log.SetFormatter(&PlainFormatter{})
 
 	client := setupRealClientSet(t)
+	filter := common.NewNamespaceFilter([]string{})
 
-	repl := NewReplicator(client, 60*time.Second, false, false)
+	repl := NewReplicator(client, 60*time.Second, false, false, filter)
 	go repl.Run()
 
 	time.Sleep(200 * time.Millisecond)
@@ -1293,7 +1294,9 @@ func TestSecretReplicatorSyncByContent(t *testing.T) {
 	client := setupRealClientSet(t)
 	ctx := context.TODO()
 
-	repl := NewReplicator(client, 60*time.Second, false, true)
+	filter := common.NewNamespaceFilter([]string{})
+
+	repl := NewReplicator(client, 60*time.Second, false, true, filter)
 	go repl.Run()
 
 	time.Sleep(200 * time.Millisecond)


### PR DESCRIPTION
##  Feature: Add `--exclude-namespaces` Flag

### Summary

This pull request introduces a new command-line flag `--exclude-namespaces`. This feature allows users to specify a comma-separated list of namespaces to exclude from the replication process of ConfigMaps and Secrets

### Implementation Details

- Added `ExcludeNamespaces` field to the configuration structure
- Implemented logic in `replicate/common/exclude.go` to handle namespace exclusion
- Integrated exclusion logic into both ConfigMap and Secret replicators
- Fixed unit tests 

### Usage Example

```bash
kubernetes-replicator --exclude-namespaces=kube-system,monitoring
```

### Benefits

This enhancement provides greater control over the replication process, allowing administrators to prevent replication into specific namespaces, which is particularly useful for maintaining security and avoiding conflicts in system-critical or sensitive namespaces