### PR TITLE
feat(chart): allow namespace override in chart

### DIFF
--- a/deploy/helm-chart/kubernetes-replicator/templates/_helpers.tpl
+++ b/deploy/helm-chart/kubernetes-replicator/templates/_helpers.tpl
@@ -32,6 +32,13 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Create namespace name using the value of the release object or custom override.
+*/}}
+{{- define "kubernetes-replicator.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "kubernetes-replicator.labels" -}}

--- a/deploy/helm-chart/kubernetes-replicator/templates/deployment.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kubernetes-replicator.fullname" . }}
+  namespace: {{ include "kubernetes-replicator.namespace" . }}
   labels:
     {{- include "kubernetes-replicator.labels" . | nindent 4 }}
     {{- if .Values.labels }}

--- a/deploy/helm-chart/kubernetes-replicator/templates/rbac.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/templates/rbac.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kubernetes-replicator.serviceAccountName" . }}
+  namespace: {{ include "kubernetes-replicator.namespace" . }}
   labels:
     {{- include "kubernetes-replicator.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
@@ -71,5 +72,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "kubernetes-replicator.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
+    namespace: {{ include "kubernetes-replicator.namespace" . }}
 {{- end -}}

--- a/deploy/helm-chart/kubernetes-replicator/templates/verticalpodautoscaler.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/templates/verticalpodautoscaler.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "kubernetes-replicator.fullname" . }}
+  namespace: {{ include "kubernetes-replicator.namespace" . }}
   labels:
     {{- include "kubernetes-replicator.labels" . | nindent 4 }}
 spec:

--- a/deploy/helm-chart/kubernetes-replicator/values.yaml
+++ b/deploy/helm-chart/kubernetes-replicator/values.yaml
@@ -5,6 +5,7 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+namespaceOverride: ""
 grantClusterAdmin: false
 automountServiceAccountToken: true
 # args:


### PR DESCRIPTION
This commit will allow to override the namespace metadata field of the provided Kubernetes objects by the Chart. It is taken into account the scope of those, meaning if they are namespaced or not.