### PR TITLE
fix: bump go version to the latest patch to fix high severity CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mittwald/kubernetes-replicator
 
-go 1.24.0
+go 1.24.9
 
 require (
 	github.com/hashicorp/go-multierror v1.1.1


### PR DESCRIPTION
There are 2 high severity CVEs that can be remediated by bumping the go version to the latest patch

Here are the details:

- [CVE-2025-4674](https://nvd.nist.gov/vuln/detail/CVE-2025-4674): 
> The go command may execute unexpected commands when operating in untrusted VCS repositories. This occurs when possibly dangerous VCS configuration is present in repositories. This can happen when a repository was fetched via one VCS (e.g. Git), but contains metadata for another VCS (e.g. Mercurial). Modules which are retrieved using the go command line, i.e. via "go get", are not affected.

requires at least go 1.24.6 to be fixed

- [CVE-2025-47907](https://nvd.nist.gov/vuln/detail/CVE-2025-47907):
> Cancelling a query (e.g. by cancelling the context passed to one of the query methods) during a call to the Scan method of the returned Rows can result in unexpected results if other queries are being made in parallel. This can result in a race condition that may overwrite the expected results with those of another query, causing the call to Scan to return either unexpected results from the other query or an error.

requires at least go 1.24.6 to be fixed