### PR TITLE
fix(serviceaccount): initialize annotations map in ReplicateDataFrom to avoid nil panic

### DIFF
--- a/replicate/serviceaccount/serviceaccounts.go
+++ b/replicate/serviceaccount/serviceaccounts.go
@@ -75,6 +75,10 @@ func (r *Replicator) ReplicateDataFrom(sourceObj interface{}, targetObj interfac
 	targetCopy := target.DeepCopy()
 	targetCopy.ImagePullSecrets = source.ImagePullSecrets
 
+	if targetCopy.Annotations == nil {
+		targetCopy.Annotations = make(map[string]string)
+	}
+
 	log.Infof("updating target %s/%s", target.Namespace, target.Name)
 
 	targetCopy.Annotations[common.ReplicatedAtAnnotation] = time.Now().Format(time.RFC3339)


### PR DESCRIPTION
ReplicateDataFrom wrote ReplicatedAt/ReplicatedFromVersion annotations into targetCopy without guaranteeing the map was non-nil. When the target ServiceAccount had no annotations (nil map from DeepCopy), this panicked with an assignment to entry in nil map. The map is now allocated when nil, mirroring the guard already present in ReplicateObjectTo.